### PR TITLE
Adjustments for Air::Component integration

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,37 +1,31 @@
 {
-  "auth": "zef:FCO",
-  "authors": [
-    "Fernando Corrêa de Oliveira"
-  ],
-  "build-depends": [
-  ],
-  "depends": [
-    "Cro::WebApp::Template",
-    "CSS::Nested"
-  ],
-  "description": "A way create web components with cro templates",
-  "license": "Artistic-2.0",
-  "name": "Cromponent",
-  "perl": "6.d",
-  "provides": {
-    "Boilerplate": "lib/Boilerplate.rakumod",
-    "Cromponent": "lib/Cromponent.rakumod",
-    "Cromponent::CroTemplateOverrides": "lib/Cromponent/CroTemplateOverrides.rakumod",
-    "Cromponent::MetaCromponentRole": "lib/Cromponent/MetaCromponentRole.rakumod",
-    "StyledComponent": "lib/StyledComponent.rakumod",
-    "StyledDiv": "lib/StyledDiv.rakumod"
-  },
-  "resources": [
-    "macro.crotmp",
-    "styled.crotmp",
-    "table.crotmp",
-    "todo-base.crotmp",
-    "todo.css"
-  ],
-  "source-url": "https://github.com/FCO/Cromponent.git",
-  "tags": [
-  ],
-  "test-depends": [
-  ],
-  "version": "0.0.12"
+    "name": "Cromponent",
+    "description": "A way create web components with cro templates",
+    "version": "0.0.12",
+    "authors": [
+        "Fernando Corrêa de Oliveira"
+    ],
+    "auth": "zef:FCO",
+    "depends": [
+        "Cro::WebApp::Template",
+        "CSS::Nested"
+    ],
+    "build-depends": [],
+    "provides": {
+        "Boilerplate": "lib/Boilerplate.rakumod",
+        "Cromponent": "lib/Cromponent.rakumod",
+        "Cromponent::CroTemplateOverrides": "lib/Cromponent/CroTemplateOverrides.rakumod",
+        "Cromponent::MetaCromponentRole": "lib/Cromponent/MetaCromponentRole.rakumod",
+        "StyledComponent": "lib/StyledComponent.rakumod",
+        "StyledDiv": "lib/StyledDiv.rakumod"
+    },
+    "resources": [
+        "macro.crotmp",
+        "styled.crotmp",
+        "table.crotmp",
+        "todo-base.crotmp",
+        "todo.css"
+    ],
+    "license": "Artistic-2.0",
+    "source-url": "https://github.com/FCO/Cromponent.git"
 }

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ You can use Cromponents in 3 distinct (and complementar) ways
 
       * `/text/<id>/toggle` -- that will load the object using the method `LOAD` and call `toggle` on it
 
-    You can also define the method `CREATE`, `DELETE`, and `UPDATE` to allow it to create other endpoints.
+    You can also define the method `ADD`, `DELETE`, and `UPDATE` to allow it to create other endpoints.
 
 AUTHOR
 ======

--- a/bin/lib/Todo.rakumod
+++ b/bin/lib/Todo.rakumod
@@ -7,7 +7,7 @@ model Todo does Cromponent {
 	has Str()  $.data is column is required;
 
 	method LOAD(Str() $id)  { Todo.^load: $id }
-	method CREATE(*%data)   { Todo.^create: |%data }
+	method ADD(*%data)   { Todo.^create: |%data }
 	method DELETE           { $.^delete }
 
 	method toggle is accessible {

--- a/bin/lib/Todo.rakumod
+++ b/bin/lib/Todo.rakumod
@@ -7,7 +7,7 @@ model Todo does Cromponent {
 	has Str()  $.data is column is required;
 
 	method LOAD(Str() $id)  { Todo.^load: $id }
-	method ADD(*%data)   { Todo.^create: |%data }
+	method ADD(*%data)      { Todo.^create: |%data }
 	method DELETE           { $.^delete }
 
 	method toggle is accessible {

--- a/lib/Cromponent.rakumod
+++ b/lib/Cromponent.rakumod
@@ -17,6 +17,7 @@ multi trait_mod:<is>(
 	:%accessible! (
 		:$name = $m.name,
 		:$returns-cromponent = False,
+		:$returns-html = False,
 		:$http-method = "GET",
 	)
 ) is export {
@@ -29,12 +30,17 @@ multi trait_mod:<is>(
 		method returns-cromponent { True }
 	}
 
+	my role ReturnsHtml {
+		method returns-html { True }
+	}
+
 	my role HTTPMethod {
 		has Str $.http-method;
 	}
 
 	$m does IsAccessible($name);
 	$m does ReturnsCromponent if $returns-cromponent;
+	$m does ReturnsHtml if $returns-html;
 	$m does HTTPMethod($http-method);
 	$m
 }

--- a/lib/Cromponent.rakumod
+++ b/lib/Cromponent.rakumod
@@ -245,7 +245,7 @@ The call to the .^add-cromponent-routes method will create (on this case) 2 endp
 
 =item C</text/<id>/toggle> -- that will load the object using the method C<LOAD> and call C<toggle> on it
 
-You can also define the method C<CREATE>, C<DELETE>, and C<UPDATE> to allow it to create other endpoints.
+You can also define the method C<ADD>, C<DELETE>, and C<UPDATE> to allow it to create other endpoints.
 
 =end item
 

--- a/lib/Cromponent/MetaCromponentRole.rakumod
+++ b/lib/Cromponent/MetaCromponentRole.rakumod
@@ -94,28 +94,13 @@ method add-cromponent-routes(
 			put ("-> '$url-part', " ~ q[$id {
 				request-body -> $data {
 					my $updated = update $id, |$data.pairs.Map;
+					if $updated.^roles.map(*.^name).first: "Cromponent" {
+						return content $updated.Str
+					}
 					$updated
 				}
 			}]).EVAL;
 		}
-
-# following was giving this error
-#		Variable '$deleted' is not declared.  Did you mean '&delete'?
-#at /Users/stephenroe/Library/CloudStorage/Dropbox/GitWorld/Air-Play/EVAL_8:5
-#------>                                                 return content ⏏$deleted.Str
-
-#		with &update {
-#			note "adding PUT $url-part$path";
-#			put ("-> '$url-part', " ~ q[$id {
-#				request-body -> $data {
-#					my $updated = update $id, |$data.pairs.Map;
-#					if $updated.^roles.map(*.^name).first: "Cromponent" {
-#						return content $deleted.Str
-#					}
-#					$updated
-#				}
-#			}]).EVAL;
-#		}
 
 		for $component.^methods.grep(*.?is-accessible) -> $meth {
 			my $name = $meth.is-accessible-name;

--- a/lib/Cromponent/MetaCromponentRole.rakumod
+++ b/lib/Cromponent/MetaCromponentRole.rakumod
@@ -139,8 +139,8 @@ method add-cromponent-routes(
 		for $component.^methods.grep(*.?is-controller) -> $meth {
 			my $name = $meth.is-controller-name;
 
+			note "adding {$meth.http-method.uc} $url-part$path/$name";
 			if $meth.http-method.uc ne "GET" {
-				note "adding {$meth.http-method.uc} $url-part$path/$name";
 				http $meth.http-method.uc, ("-> '$url-part'{", $load-sig" if $load-sig} " ~ q[, Str $__method-name {
 					request-body -> $data {
 						LOAD(] ~ $call-pars ~ Q[)."$__method-name"(|$data.pairs.Map);
@@ -151,7 +151,6 @@ method add-cromponent-routes(
 				my $query  = @params.map({", { .gist } is query"}).join: ", ";
 				my $params = @params.map({":{.name}"}).join: ", ";
 
-				note "adding GET $url-part$path/$name";
 				get ("-> '$url-part'{", $load-sig" if $load-sig}" ~ q[, Str $__method-name] ~ ($query if @params) ~ q[ {
 					LOAD(] ~ $call-pars ~ Q[)."$__method-name"(] ~ $params ~ q[);
 				}]).EVAL;

--- a/lib/Cromponent/MetaCromponentRole.rakumod
+++ b/lib/Cromponent/MetaCromponentRole.rakumod
@@ -150,7 +150,7 @@ method add-cromponent-routes(
 			}
 		}
 
-		#propose to add is-controller - unlike accessible this handles own response (eg an HTMX fragment)
+		#| is-controller trait - unlike is accessible this handles own response
 		for $component.^methods.grep(*.?is-controller) -> $meth {
 			my $name = $meth.is-controller-name;
 

--- a/lib/Cromponent/MetaCromponentRole.rakumod
+++ b/lib/Cromponent/MetaCromponentRole.rakumod
@@ -102,6 +102,7 @@ method add-cromponent-routes(
 			}]).EVAL;
 		}
 
+		#iamerejh is-controller also
 		for $component.^methods.grep(*.?is-accessible) -> $meth {
 			my $name = $meth.is-accessible-name;
 			my $returns-cromponent =  $meth.?returns-cromponent;
@@ -131,6 +132,29 @@ method add-cromponent-routes(
 					} else {
 						] ~ qq[redirect "..{ "/{ $call-pars }" if $call-pars }", :see-other
 					}
+				}]).EVAL;
+			}
+		}
+
+		#iamerejh - next => create & update
+		for $component.^methods.grep(*.?is-controller) -> $meth {
+			my $name = $meth.is-controller-name;
+
+			if $meth.http-method.uc ne "GET" {
+				note "adding {$meth.http-method.uc} $url-part$path/$name";
+				http $meth.http-method.uc, ("-> '$url-part'{", $load-sig" if $load-sig} " ~ q[, Str $__method-name {
+					request-body -> $data {
+						my $ret = LOAD(] ~ $call-pars ~ Q[)."$__method-name"(|$data.pairs.Map);
+					}
+				}]).EVAL;
+			} else {
+				my @params = $meth.signature.params.skip.head(*-1);
+				my $query  = @params.map({", { .gist } is query"}).join: ", ";
+				my $params = @params.map({":{.name}"}).join: ", ";
+
+				note "adding GET $url-part$path/$name";
+				get ("-> '$url-part'{", $load-sig" if $load-sig}" ~ q[, Str $__method-name] ~ ($query if @params) ~ q[ {
+					my $ret = LOAD(] ~ $call-pars ~ Q[)."$__method-name"(] ~ $params ~ q[);
 				}]).EVAL;
 			}
 		}


### PR DESCRIPTION
@FCO per our chat on IRC/Discord I am keen to re-establish the Air::Component module as a consumer of Cromponent.

Therefore I offer this PR that has some adjustments and now works with the Air and Air::Play modules (specifically on their "cromponent-spike" branch). I will release these as a new versions if/when you are happy to accept this PR.

The general plan for this PR is that in Air::Component, there is code like this:

```
role Air::Component does Component::Common {
    ::?CLASS.HOW does Cromponent::MetaCromponentRole;

    ...
}
```

So in fact, `role Air::Component` is at the same level as `role Cromponent` in that both of them rely on `Cromponent::MetaCromponentRole` in similar ways. 

I am pleased that you have structured `Cromponent::MetaCromponentRole` as a separate sub module as this is exactly the API to your code that I need. Also I am pleased with the way it uses `.EVAL` (although I am not sure i fully understand it).

There are three main changes in this PR:
 - I think I found a bug in the delete action (`Cromponent::MetaCromponentRole`) ... or maybe I misunderstand what the code is doing ... anyway I have cut out three lines that seem to fix the issue
 - I have added a new trait `is controller` ... similar to `is accessible` but expects the Air::Component method to handle its own response
 - I have changed CREATE to ADD to avoid conflict with the Cro::WebApp::Form module which depends on the core raku CREATE method (which I believe is reserved)

Please do feel free to open a PR discussion and we can discuss these items one by one.

Thank you for such an excellent module!

~librasteve